### PR TITLE
Support for UnifiedUI (UUI) 2.2.1 - Continued (Workshop ID 2966990700)

### DIFF
--- a/UUIRegisterShared/UUIRegister.cs
+++ b/UUIRegisterShared/UUIRegister.cs
@@ -20,7 +20,7 @@ namespace ModsCommon
     where TypeMod : ICustomMod
     where TypeTool : ToolBase, ITool
     {
-        private static PluginSearcher UUISearcher { get; } = PluginUtilities.GetSearcher("Unified UI", 2255219025ul) & new VersionSearcher(new Version(1, 3), (m, s) => m >= s);
+        private static PluginSearcher UUISearcher { get; } = PluginUtilities.GetSearcher("Unified UI", 2255219025ul, 2966990700ul) & new VersionSearcher(new Version(1, 3), (m, s) => m >= s);
         public static bool IsUUIEnabled => UUISearcher.GetPlugin()?.isEnabled == true;
 
         public bool UUIRegistered { get; private set; }


### PR DESCRIPTION
Added UnifiedUI (UUI) 2.2.1 - Continued (WorkshopID #[2966990700](https://steamcommunity.com/sharedfiles/filedetails/?id=2966990700)) to the UUI Register method. Please review the line changed. 

**UNTESTED IN-GAME - PLAN TO TEST 2023/05/26**
**PLAN TO RELEASE UPDATED UnifiedUI (UUI) 2.2.1 - Continued (compiled for resorts free update) 2023/05/26 (will leave unlisted for now and marked as beta for now)**

n.b.: Reading the method makes me wonder if it should check the namespace OR ID if both are provided; it skips the namespace check if it the ID parameter array is provided. This does prevent possible duplicate assembly issues (people should not be installing duplicate versions of the mod) but I'm not necessarily sure that is the most optimal from a maintenance standpoint; i.e., if I release a beta version (after ID=2966990700 is promoted to stable) or if someone else releases some other UUI after I go on. Regardless, with CS:2 supposedly releasing later this year, I suppose it's a non-issue, but maybe something to think about for pub/sub models in CS:2 modding. From my professional experience the namespace was the general go-to as we didn't need to update it per environment -- i.e., production, UAT, staging, QA, etc -- and if we needed to, we added support to limit it at configuration time in a settings file or administrative configuration panel, not compile time.